### PR TITLE
Removed unnecessary fields from fluentbit.yaml

### DIFF
--- a/content/intermediate/230_logging/deploy.files/fluentbit.yaml
+++ b/content/intermediate/230_logging/deploy.files/fluentbit.yaml
@@ -160,11 +160,6 @@ spec:
         imagePullPolicy: Always
         ports:
           - containerPort: 2020
-        env:
-        - name: FLUENT_ELASTICSEARCH_HOST
-          value: "elasticsearch"
-        - name: FLUENT_ELASTICSEARCH_PORT
-          value: "9200"
         volumeMounts:
         - name: varlog
           mountPath: /var/log
@@ -185,11 +180,3 @@ spec:
         configMap:
           name: fluent-bit-config
       serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"


### PR DESCRIPTION
Since the master node is not visible to the user in EKS, there is no need for tolerations settings to prevent fluentbit from being deployed to the master node.
The environment variables FLUENT_ELASTICSEARCH_HOST and FLUENT_ELASTICSEARCH_PORT are not used. These are unnecessary because they are defined directly in output-elasticsearch.conf in ConfigMap.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
